### PR TITLE
update dockerfile and script to install Playwright for python and deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ ARG base_image
 
 FROM ${base_image}
 
-ENV NODE_VERSION v20.11.0
-
 COPY . /playwright
 WORKDIR /playwright
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@ pip install playwright
 # Install Pytest Playwright
 pip install pytest-playwright
 
-# Install Playwright deps and Firefox browser for e2e tests
+# Install Playwright deps and browsers for e2e tests
 playwright install-deps
 playwright install
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,6 +22,6 @@ pip install pytest-playwright
 
 # Install Playwright deps and Firefox browser for e2e tests
 playwright install-deps
-playwright install firefox
+playwright install
 
 rm -rf /var/lib/apt/lists/*

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,26 +3,25 @@
 set -e
 
 apt-get update
-apt-get -y upgrade
 apt-get -y -q install \
-  git \
-  wget \
-  xz-utils
+  python3-pip \
+  python3-venv
 
-#install nodejs from source
-wget "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz"
-mkdir -p /usr/local/lib/nodejs
-tar -xJvf node-${NODE_VERSION}-linux-x64.tar.xz -C /usr/local/lib/nodejs
-ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/node /usr/bin/node
-ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npm /usr/bin/npm
-ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npx /usr/bin/npx
-rm -f "node-${NODE_VERSION}-linux-x64.tar.xz"
+apt-get clean
 
-npm install --global yarn
-ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/yarn /usr/bin/yarn
+# symlink python to python3 executable
+ln -s "$(which python3)" /usr/bin/python
 
-yarn add playwright
-npx playwright install-deps
-npx playwright install
+pip install --upgrade pip
+
+# Install Playwright
+pip install playwright
+
+# Install Pytest Playwright
+pip install pytest-playwright
+
+# Install Playwright deps and Firefox browser for e2e tests
+playwright install-deps
+playwright install firefox
 
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Changes proposed in this pull request:

- Changing this image to be based off of Python for Python-based Playwright testing

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None - the image is still going to use the same hardened based image and go through the normal container hardening process
