### PR TITLE
remove step to install browsers for Playwright from Dockerfile build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,6 +22,5 @@ pip install pytest-playwright
 
 # Install Playwright deps and browsers for e2e tests
 playwright install-deps
-playwright install
 
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Changes proposed in this pull request:

Pre-installing browsers for Playwright is not recommended by the official docs: https://playwright.dev/python/docs/ci#caching-browsers, nor does it seem to work correctly anyway, so this PR removes that build step

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, the CI image is still being pre-built and hardened
